### PR TITLE
Dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -630,7 +630,7 @@ This filter will hash a string using Cisco's Type 9 hashing scheme (SCrypt). An 
 
 This filter will hash a string using Juniper's Type 6 hashing scheme (Unix Crypt based SHA512). An optional "salt" (length must be 8 characters) can be provided which makes the hashed string deterministic for idempotent operations.
 
-- <b><code>xpath("query")</code></b>
+- <b><code>xpath("query")</code></b> (requires `lxml` python module)
 
 This filter is used to perform an xpath query on an XML based output and return the matching sections as a list (if you use namespaces you need to ensure you define them using the `xmlns:` syntax), e.g:
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 [![PyPI](https://img.shields.io/pypi/v/jinjafx.svg)](https://pypi.python.org/pypi/jinjafx/)
-![Python](https://img.shields.io/badge/python-≥&nbsp;3.6-brightgreen)
+![Python](https://img.shields.io/badge/python-≥&nbsp;3.7-brightgreen)
 [<img src="https://img.shields.io/badge/url-https%3A%2F%2Fjinjafx.io-blue" align="right">](https://jinjafx.io)
 &nbsp;
 <h1 align="center">JinjaFx - Jinja2 Templating Tool</h1>

--- a/README.md
+++ b/README.md
@@ -440,6 +440,9 @@ You also have the option to specify different DataSets within a DataTemplate - t
 ```yaml
 ---
 dt:
+  global: |2
+    ... GLOBAL.YML ...
+
   datasets:
     "Test":
       data: |2

--- a/extensions/ext_jinjafx.py
+++ b/extensions/ext_jinjafx.py
@@ -20,7 +20,13 @@ from cryptography.hazmat.primitives.kdf.scrypt import Scrypt
 from cryptography.hazmat.primitives.ciphers.aead import ChaCha20Poly1305
 from cryptography.hazmat.backends import default_backend
 from cryptography.exceptions import InvalidTag
-from lxml import etree
+
+try:
+  from lxml import etree
+  lxml = True
+
+except:
+  lxml = False
 
 import os, base64, random, re, crypt
 
@@ -166,17 +172,21 @@ class plugin(Extension):
     return crypt.crypt(string, '$6$' + salt)
 
   def __xpath(self, s_xml, s_path):
-    s_xml = re.sub(r'>\s+<', '><', s_xml.strip())
-    xml = etree.fromstring(s_xml, parser=etree.XMLParser(remove_comments=True, remove_pis=True))
-    xml = xml.xpath(s_path, namespaces=xml.nsmap)
+    if lxml:
+      s_xml = re.sub(r'>\s+<', '><', s_xml.strip())
+      xml = etree.fromstring(s_xml, parser=etree.XMLParser(remove_comments=True, remove_pis=True))
+      xml = xml.xpath(s_path, namespaces=xml.nsmap)
 
-    r = []
-    for x in xml:
-      if isinstance(x, str):
-        r.append(x.strip())
-      else:
-        r.append(etree.tostring(x, pretty_print=True).decode('utf-8').strip())
-    return r
+      r = []
+      for x in xml:
+        if isinstance(x, str):
+          r.append(x.strip())
+        else:
+          r.append(etree.tostring(x, pretty_print=True).decode('utf-8').strip())
+      return r
+
+    else:
+      raise Exception("'xpath' filter requires the 'lxml' python module")
 
 class Vaulty():
   def __init__(self):

--- a/extensions/ext_jinjafx.py
+++ b/extensions/ext_jinjafx.py
@@ -27,7 +27,7 @@ try:
 except:
   lxml = False
 
-import os, base64, random, re
+import os, base64, random, re, hashlib
 
 class plugin(Extension):
   def __init__(self, environment):
@@ -175,11 +175,11 @@ class plugin(Extension):
     key = key.encode('utf-8')
     klen = len(key)
 
-    h = hashes.Hash(getattr(hashes, 'SHA512')())
-    alt_h = hashes.Hash(getattr(hashes, 'SHA512')())
+    h = hashlib.sha512()
+    alt_h = hashlib.sha512()
 
     alt_h.update(key + salt.encode('utf-8') + key)
-    alt_r = alt_h.finalize()
+    alt_r = alt_h.digest()
 
     h.update(key + salt.encode('utf-8'))
 
@@ -196,27 +196,27 @@ class plugin(Extension):
 
       klen >>= 1
 
-    alt_r = h.finalize()
+    alt_r = h.digest()
 
-    h = hashes.Hash(getattr(hashes, 'SHA512')())
-    alt_h = hashes.Hash(getattr(hashes, 'SHA512')())
+    h = hashlib.sha512()
+    alt_h = hashlib.sha512()
 
     for i in range(len(key)):
       h.update(key)
 
-    t = h.finalize()
+    t = h.digest()
     p_bytes = t * (len(key) // 64)
     p_bytes += t[:(len(key) % 64)]
 
     for i in range(16 + alt_r[0]):
       alt_h.update(salt.encode('utf-8'))
 
-    t = alt_h.finalize()
+    t = alt_h.digest()
     s_bytes = t * (len(salt) // 64)
     s_bytes += t[:(len(salt) % 64)]
 
     for i in range(5000):
-      h = hashes.Hash(getattr(hashes, 'SHA512')())
+      h = hashlib.sha512()
 
       h.update(p_bytes if i & 1 else alt_r)
 
@@ -228,7 +228,7 @@ class plugin(Extension):
 
       h.update(alt_r if i & 1 else p_bytes)
 
-      alt_r = h.finalize()
+      alt_r = h.digest()
 
     ret= []
     ret.append(b64_from_24bit(alt_r[0], alt_r[21], alt_r[42], 4))

--- a/extensions/ext_jinjafx.py
+++ b/extensions/ext_jinjafx.py
@@ -50,16 +50,16 @@ class plugin(Extension):
     environment.filters['vaulty_decrypt'] = self.__vaulty.decrypt
 
   def __expand_snmpv3_key(self, password, algorithm):
-    h = hashes.Hash(getattr(hashes, algorithm.upper())())
+    h = hashlib.new(algorithm)
     h.update(((password * (1048576 // len(password))) + password[:1048576 % len(password)]).encode('utf-8'))
-    return h.finalize()
+    return h.digest()
 
   def __cisco_snmpv3_key(self, password, engineid, algorithm='sha1'):
     ekey = self.__expand_snmpv3_key(password, algorithm)
 
-    h = hashes.Hash(getattr(hashes, algorithm.upper())())
+    h = hashlib.new(algorithm)
     h.update(ekey + bytearray.fromhex(engineid) + ekey)
-    hexdigest = h.finalize().hex()
+    hexdigest = h.hexdigest()
     return ':'.join([hexdigest[i:i + 2] for i in range(0, len(hexdigest), 2)])
 
   def __junos_snmpv3_key(self, password, engineid, algorithm='sha1', prefix='80000a4c'):
@@ -74,9 +74,9 @@ class plugin(Extension):
     else:
       engineid = prefix + '04' + ''.join("{:02x}".format(ord(c)) for c in engineid)
 
-    h = hashes.Hash(getattr(hashes, algorithm.upper())())
+    h = hashlib.new(algorithm)
     h.update(ekey + bytearray.fromhex(engineid) + ekey)
-    return h.finalize().hex()
+    return h.hexdigest()
 
   def __cisco7encode(self, string, seed=False):
     KEY = 'dsfd;kfoA,.iyewrkldJKDHSUBsgvca69834ncxv9873254k;fg87'

--- a/jinjafx.py
+++ b/jinjafx.py
@@ -28,7 +28,7 @@ from cryptography.hazmat.primitives.ciphers.modes import CTR
 from cryptography.hazmat.backends import default_backend
 from cryptography.exceptions import InvalidSignature
 
-__version__ = '1.14.3'
+__version__ = '1.15.0'
 
 def main():
   try:

--- a/jinjafx.py
+++ b/jinjafx.py
@@ -15,7 +15,7 @@
 # ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
 # OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
-import sys, os, io, importlib, argparse, re, getpass, datetime, traceback
+import sys, os, io, importlib.util, argparse, re, getpass, datetime, traceback
 import jinja2, jinja2.sandbox, yaml, pytz
 
 from cryptography.hazmat.primitives import hashes
@@ -213,7 +213,7 @@ Environment Variables:
                 gvars.update(yaml.load(gyaml, Loader=yaml.SafeLoader))
 
               except Exception as e:
-                exc_source = 'global'
+                exc_source = 'dt:global'
                 raise
 
           if 'vars' in dt:
@@ -223,7 +223,7 @@ Environment Variables:
                 gvars.update(yaml.load(gyaml, Loader=yaml.SafeLoader))
 
               except Exception as e:
-                exc_source = 'vars'
+                exc_source = 'dt:vars'
                 raise
   
       elif args.d is not None:

--- a/jinjafx.py
+++ b/jinjafx.py
@@ -166,6 +166,7 @@ Environment Variables:
         with open(args.dt.name, 'rt') as f:
           dt = yaml.load(f.read(), Loader=yaml.SafeLoader)['dt']
           args.t = dt['template']
+          gv = ''
   
           if 'datasets' in dt:
             if args.ds is not None:
@@ -179,7 +180,10 @@ Environment Variables:
               if len(matches) == 1:
                 if 'data' in dt['datasets'][matches[0]]:
                   dt['data'] = dt['datasets'][matches[0]]['data']
-  
+
+                if 'global' in dt:
+                  gv = dt['global']
+
                 if 'vars' in dt['datasets'][matches[0]]:
                   dt['vars'] = dt['datasets'][matches[0]]['vars']
   
@@ -195,6 +199,11 @@ Environment Variables:
           if 'data' in dt:
             data = dt['data']
   
+          if gv:
+            gyaml = __decrypt_vault(vpw, gv)
+            if gyaml:
+              gvars.update(yaml.load(gyaml, Loader=yaml.SafeLoader))
+
           if 'vars' in dt:
             gyaml = __decrypt_vault(vpw, dt['vars'])
             if gyaml:

--- a/jinjafx.py
+++ b/jinjafx.py
@@ -30,6 +30,8 @@ from cryptography.exceptions import InvalidSignature
 __version__ = '1.15.0'
 
 def main():
+  exc_source = None
+
   try:
     if not any(x in ['-q', '-encrypt', '-decrypt'] for x in sys.argv):
       print(f'JinjaFx v{__version__} - Jinja2 Templating Tool')
@@ -91,7 +93,6 @@ Environment Variables:
     gvars = {}
     data = None
     vpw = [ None ]
-    exc_source = None
 
     if args.encrypt is not None:
       if not args.encrypt:

--- a/setup.py
+++ b/setup.py
@@ -11,10 +11,10 @@ README = (HERE / "README.md").read_text()
 README = re.sub(r'^.*\[<img', '[<img', README, flags=re.DOTALL)
 README = re.sub(r'<p.+?</p>', '', README, flags=re.DOTALL)
 
-install_requires = ["jinja2>=3.0", "pytz", "pyyaml", "cryptography>=2.7", "netaddr"]
+install_requires = ["jinja2>=3.0", "pytz", "pyyaml", "cryptography>=3.1", "netaddr"]
 
 if sys.version_info[0] == 3 and sys.version_info[1] == 6:
-  install_requires = ["jinja2>=3.0,<3.1", "pytz", "pyyaml", "cryptography>=2.7,<37.0", "netaddr"]
+  install_requires = ["jinja2>=3.0,<3.1", "pytz", "pyyaml", "cryptography>=3.1,<37.0", "netaddr"]
 
 setup(
   name="jinjafx",

--- a/setup.py
+++ b/setup.py
@@ -11,10 +11,10 @@ README = (HERE / "README.md").read_text()
 README = re.sub(r'^.*\[<img', '[<img', README, flags=re.DOTALL)
 README = re.sub(r'<p.+?</p>', '', README, flags=re.DOTALL)
 
-install_requires = ["jinja2>=3.0", "pytz", "pyyaml", "cryptography>=2.7", "netaddr", "lxml"]
+install_requires = ["jinja2>=3.0", "pytz", "pyyaml", "cryptography>=2.7", "netaddr"]
 
 if sys.version_info[0] == 3 and sys.version_info[1] == 6:
-  install_requires = ["jinja2>=3.0,<3.1", "pytz", "pyyaml", "cryptography>=2.7,<37.0", "netaddr", "lxml"]
+  install_requires = ["jinja2>=3.0,<3.1", "pytz", "pyyaml", "cryptography>=2.7,<37.0", "netaddr"]
 
 setup(
   name="jinjafx",

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ README = re.sub(r'<p.+?</p>', '', README, flags=re.DOTALL)
 
 install_requires = ["jinja2>=3.0", "pytz", "pyyaml", "cryptography>=3.1", "netaddr"]
 
-if sys.version_info[0] == 3 and sys.version_info[1] == 6:
+if sys.version_info.major == 3 and sys.version_info.minor == 6:
   install_requires = ["jinja2>=3.0,<3.1", "pytz", "pyyaml", "cryptography>=3.1,<37.0", "netaddr"]
 
 setup(


### PR DESCRIPTION
* Deprecate support for Python 3.6 as it is end of life
* Add support for the "global" section within DataTemplates
* The `xpath` filter only works if the `lxml` python module is present
* Increased version dependency on `cryptography` to remove `default_backend` use
* Moved some of the cryptograhic hashes to use hashlib as it is faster
* Replaced the deprecated `crypt` module as it will be removed in Python 3.12
* Improved exception handling by displaying more context
* Fixed a Python 3.6 issue with `importlib`